### PR TITLE
Fix wording in find last test

### DIFF
--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -74,7 +74,7 @@ describe Movie do
     end
     
     describe '.last_movie' do
-      it 'returns the first item in the movies table' do
+      it 'returns the last item in the movies table' do
         expect(Movie.last_movie.title).to eq("Movie_4")
       end
     end


### PR DESCRIPTION
The test to find the last movie uses the word first in the test description.

This replaces 'first' with the correct word 'last'